### PR TITLE
Fix flake build by updating vendorHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
           src = ./.;
 
-          vendorHash = "sha256-VCyZ2r7uK+vqIVAUv1VjHREQltvl8c/h5cA+xyQAPxs=";
+          vendorHash = "sha256-5j6knS0t+kOxxIPgjizP8pcVsY1FuJ6XIcW6vwjBnI8=";
 
           ldflags = [
             "-s"


### PR DESCRIPTION
## Summary

- Updates the `vendorHash` in `flake.nix` to fix the Nix build failure
- The build was failing with a hash mismatch error because the vendor dependencies changed but the hash wasn't updated

## Details

The Nix flake build was failing with:
```
error: hash mismatch in fixed-output derivation
         specified: sha256-VCyZ2r7uK+vqIVAUv1VjHREQltvl8c/h5cA+xyQAPxs=
            got:    sha256-5j6knS0t+kOxxIPgjizP8pcVsY1FuJ6XIcW6vwjBnI8=
```

This happened because the Go module dependencies in `go.mod` and the vendor directory had diverged from the cached hash in `flake.nix`.

## Testing

- Verified the build succeeds with `nix build`
- Build completes successfully in ~3 minutes with no errors

Fixes https://github.com/rkoster/rubionic-workspace/issues/162
Fixes https://github.com/rkoster/deskrun/issues/8