### PR TITLE
Remove unused ProcessTemplate method from kapp.Client

### DIFF
--- a/internal/kapp/kapp.go
+++ b/internal/kapp/kapp.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Client provides an interface for kapp and ytt operations
+// Client provides an interface for kapp operations
 type Client struct {
 	kubeconfig string
 	namespace  string
@@ -42,28 +42,6 @@ func NewClient(kubeconfig, namespace string) *Client {
 		kubeconfig: kubeconfig,
 		namespace:  namespace,
 	}
-}
-
-// ProcessTemplate executes ytt to process templates with data values
-func (c *Client) ProcessTemplate(templateDir string, dataValuesPath string) (string, error) {
-	// Use os/exec to run ytt directly, as the ytt library seems to have output redirection issues
-	cmd := exec.Command("ytt",
-		"-f", templateDir,
-		"--data-values-file", dataValuesPath,
-	)
-
-	output, err := cmd.Output()
-	if err != nil {
-		// Get stderr for better error reporting
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("ytt failed: %w\nstderr: %s", err, string(exitErr.Stderr))
-		}
-		return "", fmt.Errorf("ytt failed: %w", err)
-	}
-
-	result := string(output)
-
-	return result, nil
 }
 
 // Deploy deploys resources using kapp
@@ -126,7 +104,7 @@ type KappListOutput struct {
 
 // List lists all kapp apps using JSON output for reliable parsing
 func (c *Client) List() ([]string, error) {
-	// Use os/exec to run kapp directly, similar to how ProcessTemplate uses ytt
+	// Use os/exec to run kapp directly
 	cmd := exec.Command("kapp",
 		"list",
 		"--kubeconfig-context", c.kubeconfig,


### PR DESCRIPTION
## Summary

Removes the unused `ProcessTemplate` method from `kapp.Client` that contained shell execution code for ytt.

## Changes

- **Removed**: `ProcessTemplate` method from `kapp.Client` (22 lines)
- **Updated**: Comment on `Client` struct to reflect it only handles kapp operations
- **Updated**: Comment in `List` method that incorrectly referenced the removed method

## Rationale

1. **Dead Code**: The method is completely unused - no calls to it exist anywhere in the codebase
2. **Anti-pattern**: Used shell execution (`exec.Command("ytt", ...)`) instead of Go libraries
3. **Redundant**: All template processing is properly handled by `templates.Processor.ProcessTemplate` which uses the ytt Go library
4. **Confusing**: Having two different `ProcessTemplate` methods was misleading

## Evidence of No Impact

- Grep search confirms zero usage of `kappClient.ProcessTemplate` or `kapp.Client.ProcessTemplate`
- All 37+ references to `ProcessTemplate` in the codebase call `processor.ProcessTemplate` from the templates package
- No tests exist for the kapp package, so no test updates needed
- All other tests pass successfully

## Code Review

The `internal/kapp/kapp.go` file now focuses solely on kapp deployment operations:
- `Deploy()` - Deploy resources
- `Delete()` - Delete apps
- `List()` - List apps
- `InspectJSON()` - Inspect app resources

Template processing remains in its proper place: the `templates.Processor` type which uses the ytt Go library correctly.

Fixes https://github.com/rkoster/deskrun/issues/11