### PR TITLE
Fix deskrun up regression - Set default apply options in kapp Delete

### DIFF
--- a/internal/kapp/kapp.go
+++ b/internal/kapp/kapp.go
@@ -125,6 +125,9 @@ func (c *Client) Delete(appName string) error {
 	deleteOpts.AppFlags.Name = appName
 	deleteOpts.AppFlags.NamespaceFlags.Name = c.namespace
 
+	// Set default apply options (required to prevent throttle panic)
+	c.setDefaultDeleteOptions(deleteOpts)
+
 	// Execute delete (non-interactive mode is handled by createConfUI based on UIConfig.Silent)
 	return deleteOpts.Run()
 }
@@ -350,4 +353,28 @@ func (c *Client) setDefaultApplyOptions(deployOpts *cmdapp.DeployOptions) {
 	// Set default exit behavior
 	deployOpts.ApplyFlags.ExitEarlyOnApplyError = true
 	deployOpts.ApplyFlags.ExitEarlyOnWaitError = true
+}
+
+// setDefaultDeleteOptions sets the default delete options that match kapp CLI defaults.
+// This is required to prevent panics and ensure consistent behavior with the CLI.
+func (c *Client) setDefaultDeleteOptions(deleteOpts *cmdapp.DeleteOptions) {
+	// Set default cluster change options (matches kapp delete CLI defaults)
+	deleteOpts.ApplyFlags.ApplyIgnored = false
+	deleteOpts.ApplyFlags.Wait = true
+	deleteOpts.ApplyFlags.WaitIgnored = false
+
+	// Set default applying changes options (prevents throttle panic)
+	deleteOpts.ApplyFlags.ApplyingChangesOpts.Concurrency = 5
+	deleteOpts.ApplyFlags.ApplyingChangesOpts.Timeout = 15 * time.Minute
+	deleteOpts.ApplyFlags.ApplyingChangesOpts.CheckInterval = 1 * time.Second
+
+	// Set default waiting changes options
+	deleteOpts.ApplyFlags.WaitingChangesOpts.Concurrency = 5
+	deleteOpts.ApplyFlags.WaitingChangesOpts.Timeout = 15 * time.Minute
+	deleteOpts.ApplyFlags.WaitingChangesOpts.CheckInterval = 3 * time.Second
+	deleteOpts.ApplyFlags.ResourceTimeout = 0 * time.Second
+
+	// Set default exit behavior
+	deleteOpts.ApplyFlags.ExitEarlyOnApplyError = true
+	deleteOpts.ApplyFlags.ExitEarlyOnWaitError = true
 }


### PR DESCRIPTION
## Summary

- Fixes panic in `deskrun up` caused by missing concurrency settings in kapp Delete operation
- Adds `setDefaultDeleteOptions()` method to mirror the existing `setDefaultApplyOptions()` for Deploy

## Problem

The `deskrun up` command was panicking with:
```
panic: Expected maximum throttle to be >= 1, but was 0
```

This occurred when the command tried to uninstall an existing runner before reinstalling it (line 107 in `internal/cmd/up.go`).

## Root Cause

The `kapp.Delete()` method was calling the kapp library without setting required default options, particularly the `Concurrency` value which must be >= 1. The `Deploy()` method already had these defaults via `setDefaultApplyOptions()`, but `Delete()` was missing this initialization.

## Solution

Added a new `setDefaultDeleteOptions()` method that sets all required defaults for delete operations:
- **Concurrency**: 5 (prevents throttle panic)
- **Timeout**: 15 minutes
- **CheckInterval**: 1 second (apply) / 3 seconds (wait)
- **Wait flags**: Enabled with proper ignore settings
- **Exit behavior**: Early exit on errors

The new method mirrors the structure of `setDefaultApplyOptions()` to ensure consistent behavior between deploy and delete operations.

## Testing

- All existing tests pass
- The fix matches kapp CLI defaults to ensure consistent behavior
- Manual testing would confirm the panic is resolved

Fixes https://github.com/rkoster/deskrun/issues/19