### PR TITLE
Fix missing GitHub Actions workspace directories in privileged mode

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -508,6 +508,20 @@ data:
 		}
 	}
 
+	// Add GitHub Actions workspace directory volume mounts
+	// These directories are required by the GitHub Actions runner and workflow scripts
+	hookExtension += `
+        - name: gh-ws-temp
+          mountPath: /__w/_temp
+        - name: gh-ws-actions
+          mountPath: /__w/_actions
+        - name: gh-ws-tool
+          mountPath: /__w/_tool
+        - name: github-home
+          mountPath: /github/home
+        - name: github-flow
+          mountPath: /github/workflow`
+
 	// Add volume definitions (system mounts + cache volumes needed by job container)
 	// Cache volumes are only needed for job containers, not the runner container
 	hookExtension += `
@@ -553,6 +567,20 @@ data:
 				i, hostPath)
 		}
 	}
+
+	// Add GitHub Actions workspace directory volumes
+	// These use emptyDir to provide temporary directories for each job pod
+	hookExtension += `
+      - name: gh-ws-temp
+        emptyDir: {}
+      - name: gh-ws-actions
+        emptyDir: {}
+      - name: gh-ws-tool
+        emptyDir: {}
+      - name: github-home
+        emptyDir: {}
+      - name: github-flow
+        emptyDir: {}`
 
 	return hookExtension
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -231,13 +231,25 @@ func TestGenerateHookExtensionConfigMap(t *testing.T) {
 				"path: /dev/pts",
 				"path: /dev/shm",
 				"type: Directory",
+				// GitHub Actions workspace directories
+				"mountPath: /__w/_temp",
+				"mountPath: /__w/_actions",
+				"mountPath: /__w/_tool",
+				"mountPath: /github/home",
+				"mountPath: /github/workflow",
+				"name: gh-ws-temp",
+				"name: gh-ws-actions",
+				"name: gh-ws-tool",
+				"name: github-home",
+				"name: github-flow",
+				"emptyDir: {}",
 			},
 			wantNotContains: []string{
 				// Hook extension should NOT contain runner-specific config
 				"ACTIONS_RUNNER_CONTAINER_HOOKS",
 				"runAsNonRoot: true",
-				// Should not duplicate volumes already in template
-				"work",
+				// Should not duplicate volumes already in template (check for exact volume name)
+				"name: work",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

This PR fixes missing GitHub Actions workspace directories in privileged container mode by adding the required volume mounts and volumes to the hook extension ConfigMap.

## Problem

When using `deskrun` with `cached-privileged-kubernetes` mode, jobs fail with errors like:

```
/home/runner/k8s-novolume/index.js:3
    fs.mkdirSync('/__w/_temp', { recursive: true });
                      ^
Error: ENOENT: no such file or directory, open '/__w/_temp/package.json'
```

This occurs because the hook extension ConfigMap doesn't include volume mounts for GitHub Actions workspace directories that the runner expects to exist.

## Solution

Modified the `generateHookExtensionConfigMap()` function in `internal/runner/runner.go` to add the required GitHub Actions workspace volume mounts and volumes:

**Volume mounts added to job container:**
- `/__w/_temp` - For temporary script files
- `/__w/_actions` - For actions cache  
- `/__w/_tool` - For tool cache
- `/github/home` - For GitHub home directory
- `/github/workflow` - For GitHub workflow directory

**Volume definitions:**
All volumes use `emptyDir: {}` to provide temporary directories for each job pod.

## Benefits

1. **Fixes root cause** - Addresses the missing directories in deskrun itself
2. **Universal compatibility** - Works with any container image (Nixery, Alpine, Ubuntu, etc.)
3. **No custom images required** - Works out of the box with standard images
4. **Maintains compatibility** - Preserves all existing deskrun features
5. **Proper solution** - Not a workaround but the correct fix

## Testing

- All existing tests pass
- Updated test to verify the new workspace directories are present
- Test correctly validates that the "work" volume (from runner template) is not duplicated

Fixes https://github.com/rkoster/deskrun/issues/21