### PR TITLE
Fix: Add dummy volume to force k8s-novolume hook prepare script execution

### DIFF
--- a/internal/runner/template_spec/testdata/expected/privileged_basic.yaml
+++ b/internal/runner/template_spec/testdata/expected/privileged_basic.yaml
@@ -293,6 +293,8 @@ data:
           mountPath: /lib64
         - name: glibc-compat
           mountPath: /lib/x86_64-linux-gnu
+        - name: dummy-prepare-trigger
+          mountPath: /tmp/dummy-prepare
       volumes:
       - name: sys
         hostPath:
@@ -319,6 +321,8 @@ data:
           path: /dev/shm
           type: Directory
       - name: glibc-compat
+        emptyDir: {}
+      - name: dummy-prepare-trigger
         emptyDir: {}
 ---
 apiVersion: actions.github.com/v1alpha1

--- a/internal/runner/template_spec/testdata/expected/privileged_multi_cache.yaml
+++ b/internal/runner/template_spec/testdata/expected/privileged_multi_cache.yaml
@@ -297,6 +297,8 @@ data:
           mountPath: /var/lib/docker
         - name: cache-1
           mountPath: /nix/store
+        - name: dummy-prepare-trigger
+          mountPath: /tmp/dummy-prepare
       volumes:
       - name: sys
         hostPath:
@@ -332,6 +334,8 @@ data:
         hostPath:
           path: /nix/store
           type: DirectoryOrCreate
+      - name: dummy-prepare-trigger
+        emptyDir: {}
 ---
 apiVersion: actions.github.com/v1alpha1
 kind: AutoscalingRunnerSet

--- a/pkg/templates/templates/overlay.yaml
+++ b/pkg/templates/templates/overlay.yaml
@@ -76,6 +76,11 @@
 #@     volumeMounts.append({"name": "cache-" + str(i), "mountPath": cachePath.target})
 #@   end
 #@   
+#@   # WORKAROUND: Add dummy user mount volume to force k8s-novolume hook prepare script execution
+#@   # The prepare script only runs when userMountVolumes exist, but it's needed to copy /github/workflow content
+#@   # See: https://github.com/rkoster/deskrun/issues/26
+#@   volumeMounts.append({"name": "dummy-prepare-trigger", "mountPath": "/tmp/dummy-prepare"})
+#@   
 #@   # Note: externals (/__e), work (/__w), and github (/github) volumes are automatically
 #@   # added by the k8s-novolume hooks, so we don't include them here to avoid duplicates.
 #@   # The hooks handle all GitHub workspace paths including /github/workflow/event.json
@@ -108,6 +113,9 @@
 #@     end
 #@     volumes.append({"name": "cache-" + str(i), "hostPath": {"path": cache_source, "type": "DirectoryOrCreate"}})
 #@   end
+#@   
+#@   # WORKAROUND: Dummy volume to trigger prepare script (see volumeMounts comment above)
+#@   volumes.append({"name": "dummy-prepare-trigger", "emptyDir": {}})
 #@   
 #@   spec["containers"] = [container]
 #@   spec["volumes"] = volumes

--- a/pkg/templates/testdata/expected/privileged_basic.yaml
+++ b/pkg/templates/testdata/expected/privileged_basic.yaml
@@ -293,6 +293,8 @@ data:
           mountPath: /lib64
         - name: glibc-compat
           mountPath: /lib/x86_64-linux-gnu
+        - name: dummy-prepare-trigger
+          mountPath: /tmp/dummy-prepare
       volumes:
       - name: sys
         hostPath:
@@ -319,6 +321,8 @@ data:
           path: /dev/shm
           type: Directory
       - name: glibc-compat
+        emptyDir: {}
+      - name: dummy-prepare-trigger
         emptyDir: {}
 ---
 apiVersion: actions.github.com/v1alpha1

--- a/pkg/templates/testdata/expected/privileged_emptydir_cache.yaml
+++ b/pkg/templates/testdata/expected/privileged_emptydir_cache.yaml
@@ -295,6 +295,8 @@ data:
           mountPath: /lib/x86_64-linux-gnu
         - name: cache-0
           mountPath: /var/lib/docker
+        - name: dummy-prepare-trigger
+          mountPath: /tmp/dummy-prepare
       volumes:
       - name: sys
         hostPath:
@@ -326,6 +328,8 @@ data:
         hostPath:
           path: /tmp/github-runner-cache/test-runner-1/cache-0
           type: DirectoryOrCreate
+      - name: dummy-prepare-trigger
+        emptyDir: {}
 ---
 apiVersion: actions.github.com/v1alpha1
 kind: AutoscalingRunnerSet

--- a/pkg/templates/testdata/expected/privileged_multi_cache.yaml
+++ b/pkg/templates/testdata/expected/privileged_multi_cache.yaml
@@ -297,6 +297,8 @@ data:
           mountPath: /var/lib/docker
         - name: cache-1
           mountPath: /nix/store
+        - name: dummy-prepare-trigger
+          mountPath: /tmp/dummy-prepare
       volumes:
       - name: sys
         hostPath:
@@ -332,6 +334,8 @@ data:
         hostPath:
           path: /nix/store
           type: DirectoryOrCreate
+      - name: dummy-prepare-trigger
+        emptyDir: {}
 ---
 apiVersion: actions.github.com/v1alpha1
 kind: AutoscalingRunnerSet

--- a/pkg/templates/testdata/expected/privileged_single_cache.yaml
+++ b/pkg/templates/testdata/expected/privileged_single_cache.yaml
@@ -295,6 +295,8 @@ data:
           mountPath: /lib/x86_64-linux-gnu
         - name: cache-0
           mountPath: /var/lib/docker
+        - name: dummy-prepare-trigger
+          mountPath: /tmp/dummy-prepare
       volumes:
       - name: sys
         hostPath:
@@ -326,6 +328,8 @@ data:
         hostPath:
           path: /var/lib/docker
           type: DirectoryOrCreate
+      - name: dummy-prepare-trigger
+        emptyDir: {}
 ---
 apiVersion: actions.github.com/v1alpha1
 kind: AutoscalingRunnerSet


### PR DESCRIPTION
## Summary

Add a dummy EmptyDir volume mount to the `cached-privileged-kubernetes` container mode to work around a bug in GitHub's `runner-container-hooks` that prevents `/github/workflow/event.json` from being populated.

Fixes https://github.com/rkoster/deskrun/issues/26

## Problem

When using `cached-privileged-kubernetes` mode, the "Set up Docker Buildx" action fails because `/github/workflow/event.json` does not exist. This file is required by Docker Buildx to read the `$GITHUB_EVENT_PATH` environment variable.

## Root Cause

The bug is in GitHub's `runner-container-hooks` package at `packages/k8s/src/hooks/prepare-job.ts`:

```typescript
let prepareScript: { containerPath: string; runnerPath: string } | undefined
if (args.container?.userMountVolumes?.length) {
    prepareScript = prepareJobScript(args.container.userMountVolumes || [])
}
```

The prepare script (which copies `/github/workflow` and `/github/home` content) **only gets created and executed if there are `userMountVolumes`**. Without any user volumes, the prepare script is never run, leaving `/github/workflow` empty.

## Solution

This PR adds a dummy volume mount at `/tmp/dummy-prepare` to trigger the conditional logic that creates the prepare script. The prepare script itself copies the GitHub workspace directories as a side effect.

## Changes

### `/pkg/templates/templates/overlay.yaml`

1. **Added dummy volume mount** (after line 77):
   ```yaml
   # WORKAROUND: Add dummy user mount volume to force k8s-novolume hook prepare script execution
   # The prepare script only runs when userMountVolumes exist, but it's needed to copy /github/workflow content
   # See: https://github.com/rkoster/deskrun/issues/26
   volumeMounts.append({"name": "dummy-prepare-trigger", "mountPath": "/tmp/dummy-prepare"})
   ```

2. **Added dummy volume** (after line 110):
   ```yaml
   # WORKAROUND: Dummy volume to trigger prepare script (see volumeMounts comment above)
   volumes.append({"name": "dummy-prepare-trigger", "emptyDir": {}})
   ```

## Testing

- ✅ All existing unit tests pass
- ✅ Updated test fixtures for privileged mode to include the dummy volume
- ✅ No changes to `dind` or `kubernetes` modes
- ✅ The dummy EmptyDir volume is harmless and ephemeral

## Scope

- **Affected Mode**: `cached-privileged-kubernetes` only
- **Other Modes**: `dind` and `kubernetes` are unaffected

## Future Work

- Report upstream bug to `actions/runner-container-hooks` repository
- Remove workaround once upstream fix is available